### PR TITLE
fixed some inconsistency issues in "nowplaying" action

### DIFF
--- a/plugin/js/actions/nowPlaying.js
+++ b/plugin/js/actions/nowPlaying.js
@@ -10,6 +10,7 @@ class NowPlayingAction extends Action {
     if (this.foobarCurrentPlayback.playbackState === "stopped") {
       websocketUtils.setTitle(this.context, "Stopped");
     } else {
+      intervals[this.context] && clearInterval(intervals[this.context]);
       websocketUtils.setAsyncTitleMultiline(
         this.foobarCurrentPlayback.activeItem.columns[1],
         this.foobarCurrentPlayback.activeItem.columns[0],

--- a/plugin/js/utils/eventsource.js
+++ b/plugin/js/utils/eventsource.js
@@ -87,6 +87,9 @@ eventSource.onmessage = function ({ data }) {
   const { player } = JSON.parse(data);
   if (player) {
     foobarPlayerState = player;
+    if(typeof contexts === typeof undefined){
+      return;
+    }
     updatePlayPauseActions(player);
     updateToggleMuteActions(player);
     updateCurrentVolumeActions(player);

--- a/plugin/js/utils/eventsource.js
+++ b/plugin/js/utils/eventsource.js
@@ -54,6 +54,7 @@ const updateCurrentPlaying = (player) => {
           player.activeItem.index
         )
         .then((res) => {
+          foobarPlayerArtwork = res;
           websocketUtils.setImage(context, res);
         });
       currentPlayingArtist = player.activeItem.columns[0];

--- a/plugin/js/utils/eventsource.js
+++ b/plugin/js/utils/eventsource.js
@@ -61,10 +61,10 @@ const updateCurrentPlaying = (player) => {
           foobarPlayerArtwork = res;
           websocketUtils.setImage(context, res);
         });
-      currentPlayingArtist = player.activeItem.columns[0];
-      currentPlayingTitle = player.activeItem.columns[1];
     }
   });
+  currentPlayingArtist = player.activeItem.columns[0];
+  currentPlayingTitle = player.activeItem.columns[1];
 };
 
 const parameters = {

--- a/plugin/js/utils/eventsource.js
+++ b/plugin/js/utils/eventsource.js
@@ -29,6 +29,10 @@ let currentPlayingArtist = "";
 let currentPlayingTitle = "";
 
 const updateCurrentPlaying = (player) => {
+  if (player.activeItem.playlistIndex === -1 || player.activeItem.index === -1) {
+    return;
+  }
+
   contexts.nowPlayingAction.forEach((context) => {
     if (player.playbackState === "stopped") {
       intervals[context] && clearInterval(intervals[context]);

--- a/plugin/js/utils/foobar.js
+++ b/plugin/js/utils/foobar.js
@@ -125,6 +125,9 @@ const foobar = {
         ctx.drawImage(img, 0, 0, 144, 144);
         resolve(canvas.toDataURL());
       };
+      img.onerror = function() {
+        resolve(canvas.toDataURL());
+      };
       img.src = `${foobar.baseUrl}/artwork/${playlistId}/${index}?${Date.now()}`;
     })
     return data;


### PR DESCRIPTION
I fixed some inconsistency issues in "nowplaying" action, and trivial errors caused on Chrome console.

 - The inconsistency sometimes happens when Stream Deck pane returns from sleep or another page after foobar plays the next track by time elapsed or manual operation with foobar app UI.
 b4fcd7d92652d46a0f8a149ba8b016572931cad5 and 1f62373e203fd378c9cba295f81650c7c9017b59

 - And I fixed another inconsistency issue that happens when multi "nowplaying" actions exist.
(I want to divide the title and art cover into other tiles because of visibility, so deploy two "nowplaying" actions)
b80b044f80735ae54fa3094512e4bc67c144e4e8

I know you are busy but please kindly review and take in when you have time.